### PR TITLE
Add the support for solaire-mode

### DIFF
--- a/flexoki-themes.el
+++ b/flexoki-themes.el
@@ -101,19 +101,18 @@
        (flexoki-colour-300   "#b7b5ac")
        (flexoki-colour-200   "#cecdc3")
        (flexoki-colour-100   "#e6e4d9")
-       (flexoki-colour-050   "#f2f2e4")
        (flexoki-colour-paper "#fffcf0")
        (flexoki-themes-bg
 	(if (eq variant 'light)
 	    flexoki-colour-paper flexoki-colour-black))
        (flexoki-themes-solaire-bg
 	(if (eq variant 'light)
-	    flexoki-colour-050 flexoki-colour-800))
+	    flexoki-colour-200 flexoki-colour-800))
        (flexoki-themes-faint-bg
 	(if (eq variant 'light)
 	    flexoki-colour-100 flexoki-colour-900))
        (flexoki-themes-faint-fg
-  (if (eq variant 'light)
+	(if (eq variant 'light)
 	    flexoki-colour-800 flexoki-colour-300))
        (flexoki-themes-fg
 	(if (eq variant 'light) "#100f0f" "#fffcf0"))

--- a/flexoki-themes.el
+++ b/flexoki-themes.el
@@ -101,15 +101,19 @@
        (flexoki-colour-300   "#b7b5ac")
        (flexoki-colour-200   "#cecdc3")
        (flexoki-colour-100   "#e6e4d9")
+       (flexoki-colour-050   "#f2f2e4")
        (flexoki-colour-paper "#fffcf0")
        (flexoki-themes-bg
 	(if (eq variant 'light)
 	    flexoki-colour-paper flexoki-colour-black))
+       (flexoki-themes-solaire-bg
+	(if (eq variant 'light)
+	    flexoki-colour-050 flexoki-colour-800))
        (flexoki-themes-faint-bg
 	(if (eq variant 'light)
 	    flexoki-colour-100 flexoki-colour-900))
        (flexoki-themes-faint-fg
-	(if (eq variant 'light)
+  (if (eq variant 'light)
 	    flexoki-colour-800 flexoki-colour-300))
        (flexoki-themes-fg
 	(if (eq variant 'light) "#100f0f" "#fffcf0"))
@@ -819,7 +823,10 @@
      `(web-mode-html-attr-name-face ((t (:foreground ,flexoki-themes-orange))))
      `(web-mode-json-key-face
        ((t (:inherit font-lock-keyword-face :weight light))))
-     `(web-mode-json-context-face ((t (:inherit font-lock-keyword-face)))))))
+     `(web-mode-json-context-face ((t (:inherit font-lock-keyword-face))))
+
+;;;;;; solaire-mode
+     `(solaire-default-face ((t (:background ,flexoki-themes-solaire-bg)))))))
 
 ;;;###autoload
 (and load-file-name


### PR DESCRIPTION
This PR adds `solaire-default-face` to minimally support `solaire-mode` (https://github.com/hlissner/emacs-solaire-mode). 

A new color is tentatively added for a subtler effect, but the exact colors to use for both the light and dark themes are open to discussion. Please make suggestions, if any.